### PR TITLE
番組の開始または終了時刻変更への追随性改善

### DIFF
--- a/src/model/ModelContainer.ts
+++ b/src/model/ModelContainer.ts
@@ -3,6 +3,6 @@ import { Container } from 'inversify';
 /**
  * container に 各 Model を登録する
  */
-const container = new Container();
+const container = new Container({ skipBaseClassChecks: true });
 
 export default container;

--- a/src/model/epgUpdater/EPGUpdateManageModel.ts
+++ b/src/model/epgUpdater/EPGUpdateManageModel.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-case-declarations */
+import { EventEmitter } from 'events';
 import { IncomingMessage } from 'http';
 import { inject, injectable } from 'inversify';
 import mirakurun from 'mirakurun';
@@ -11,14 +12,15 @@ import ILogger from '../ILogger';
 import ILoggerModel from '../ILoggerModel';
 import IMirakurunClientModel from '../IMirakurunClientModel';
 import IEPGUpdateManageModel, {
-    CreateEvent,
     ProgramBaseEvent,
+    UpdateEvent,
+    RemoveEvent,
     RedefineEvent,
     ServiceEvent,
 } from './IEPGUpdateManageModel';
 
 @injectable()
-class EPGUpdateManageModel implements IEPGUpdateManageModel {
+class EPGUpdateManageModel extends EventEmitter implements IEPGUpdateManageModel {
     private log: ILogger;
     private mirakurunClient: mirakurun;
     private channelDB: IChannelDB;
@@ -42,6 +44,8 @@ class EPGUpdateManageModel implements IEPGUpdateManageModel {
         @inject('IChannelDB') channelDB: IChannelDB,
         @inject('IProgramDB') programDB: IProgramDB,
     ) {
+        super();
+
         this.log = loggerModel.getLogger();
         this.mirakurunClient = mirakurunClientModel.getClient();
         this.channelDB = channelDB;
@@ -304,56 +308,95 @@ class EPGUpdateManageModel implements IEPGUpdateManageModel {
     /**
      * programQueue の program を DB へ反映させる
      */
-    public async saveProgram(): Promise<void> {
+    public async saveProgram(timeThreshold: number = 0): Promise<void> {
         // 取り出し
         const programs = this.programQueue.splice(0, this.programQueue.length);
-
         if (programs.length === 0) {
             return;
         }
+        this.log.system.debug('number of de-queued items: %d', programs.length);
 
-        this.log.system.info('start save program');
+        try {
+            const deleteIndex: { [programId: number]: ProgramBaseEvent } = {}; // 追加用索引
+            const updateIndex: { [programId: number]: ProgramBaseEvent } = {}; // 追加用索引
+            let needToSave = false;
 
-        const deleteIndex: { [programId: number]: mapid.ProgramId } = {}; // 削除用索引
-        const createIndex: { [programId: number]: mapid.Program } = {}; // 追加用索引
-        const updateIndex: { [programId: number]: mapid.Program } = {}; // 更新用索引
+            if (timeThreshold === 0) needToSave = true;
 
-        for (const program of programs) {
-            if (program.type === 'create') {
-                const createData = (<CreateEvent>program).data;
-                if (typeof createData.name !== 'undefined' && this.isMainProgram(createData) === true) {
-                    createIndex[createData.id] = createData;
+            // eventを時系列を意識して整理
+            for (const event of programs) {
+                if (event.type === 'create' || event.type === 'update') {
+                    const program = (<UpdateEvent>event).data;
+                    if (typeof program.name !== 'undefined' && this.isMainProgram(program) === true) {
+                        updateIndex[program.id] = event;
+                        if (program.startAt < timeThreshold) needToSave = true;
+                        if (program.id in deleteIndex) {
+                            // このEvent以前に受信した"remove" or "redefine" Eventは破棄する
+                            delete deleteIndex[program.id];
+                        }
+                    }
+                } else if (event.type === 'remove') {
+                    const removeData = (<RemoveEvent>event).data;
+                    deleteIndex[removeData.id] = event;
+                    if (removeData.id in updateIndex) {
+                        // このEvent以前に受信した"create" or "update" Eventは破棄する
+                        delete updateIndex[removeData.id];
+                    }
+                } else if ((event as any).type === 'redefine') {
+                    // redefine は古いバージョンをサポートするため
+                    const from = (<RedefineEvent>event).data.from;
+                    deleteIndex[from] = event;
+                    if (from in updateIndex) {
+                        // このEvent以前に受信した"create" or "update" Eventは破棄する
+                        delete updateIndex[from];
+                    }
                 }
-            } else if (program.type === 'update') {
-                const updateData = (<CreateEvent>program).data;
-                if (typeof updateData !== 'undefined' && this.isMainProgram(updateData) === true) {
-                    updateIndex[updateData.id] = updateData;
-                }
-            } else if (program.type === 'remove' || (program as any).type === 'redefine') {
-                // redefine は古いバージョンをサポートするため
-                const from = (<RedefineEvent>program).data.from;
-                deleteIndex[from] = from;
             }
+
+            if (needToSave) {
+                const deleteValues: Array<mapid.ProgramId> = [];
+                const insertValues: Array<mapid.Program> = [];
+                const updateValues: Array<mapid.Program> = [];
+
+                for (const [_id, event] of Object.entries(deleteIndex)) {
+                    deleteValues.push((<RemoveEvent>event).data.id);
+                }
+                for (const [_id, event] of Object.entries(updateIndex)) {
+                    updateValues.push((<UpdateEvent>event).data);
+                }
+
+                if (deleteValues.length > 0 || insertValues.length > 0 || updateValues.length > 0) {
+                    this.log.system.info('update program db start');
+                    this.log.system.info({
+                        deleteValues: deleteValues.length,
+                        insertValues: insertValues.length,
+                        updateValues: updateValues.length,
+                    });
+
+                    await this.programDB.update(this.channelIndex, {
+                        insert: insertValues,
+                        update: updateValues,
+                        delete: deleteValues,
+                    });
+                    this.log.system.info('update program db done');
+
+                    this.emit('program updated');
+                }
+            } else {
+                // 整理した結果のEventをキューへ戻す
+                // NOTE: "remove"イベントは先頭へ
+                this.log.system.debug(
+                    'number of re-queued items: %d',
+                    Object.keys(deleteIndex).length + Object.keys(updateIndex).length,
+                );
+                this.programQueue = Object.values(deleteIndex).concat(Object.values(updateIndex), this.programQueue);
+            }
+        } catch (err: any) {
+            // キューへ全て戻す
+            this.log.system.debug('number of re-queued items: %d', programs.length);
+            this.programQueue = programs.concat(this.programQueue);
+            throw err;
         }
-
-        const deleteValues = Object.values(deleteIndex);
-        const insertValues = Object.values(createIndex);
-        const updateValues = Object.values(updateIndex);
-
-        this.log.system.info({
-            deleteValues: deleteValues.length,
-            insertValues: insertValues.length,
-            updateValues: updateValues.length,
-        });
-
-        this.log.system.info('update db');
-        await this.programDB.update(this.channelIndex, {
-            insert: insertValues,
-            update: updateValues,
-            delete: deleteValues,
-        });
-
-        this.log.system.info('update db done');
     }
 
     /**
@@ -366,7 +409,7 @@ class EPGUpdateManageModel implements IEPGUpdateManageModel {
     /**
      * serviceQueue の program を DB へ反映させる
      */
-    public async saveSevice(): Promise<void> {
+    public async saveService(): Promise<void> {
         // 取り出し
         const services = this.serviceQueue.splice(0, this.serviceQueue.length);
 
@@ -387,8 +430,6 @@ class EPGUpdateManageModel implements IEPGUpdateManageModel {
 
         const createIndex: { [serviceId: number]: mapid.Service } = {}; // 追加用索引
         const updateIndex: { [serviceId: number]: mapid.Service } = {}; // 更新用索引
-
-        this.log.system.info('start save service');
 
         for (const service of services) {
             if (
@@ -424,12 +465,12 @@ class EPGUpdateManageModel implements IEPGUpdateManageModel {
         const insertValues = Object.values(createIndex);
         const updateValues = Object.values(updateIndex);
 
+        this.log.system.info('update channel db start');
         this.log.system.info({
             insertValues: insertValues.length,
             updateValues: updateValues.length,
         });
 
-        this.log.system.info('update db');
         await this.channelDB.update({
             insert: insertValues,
             update: updateValues,
@@ -439,7 +480,8 @@ class EPGUpdateManageModel implements IEPGUpdateManageModel {
         this.updateChannelIndex(insertValues);
         this.updateChannelIndex(updateValues);
 
-        this.log.system.info('update db done');
+        this.log.system.info('update channel db done');
+        this.emit('service updated');
     }
 }
 

--- a/src/model/epgUpdater/EPGUpdateManageModel.ts
+++ b/src/model/epgUpdater/EPGUpdateManageModel.ts
@@ -208,12 +208,15 @@ class EPGUpdateManageModel extends EventEmitter implements IEPGUpdateManageModel
             throw err;
         });
 
+        this.emit('event stream started');
+
         return new Promise<void>(async (_resolve: () => void, reject: (err: Error) => void) => {
             // エラー処理
             eventStream.once('error', err => {
                 this.log.system.error('event stream error');
                 this.log.system.error(err);
                 this.stopStream(eventStream);
+                this.emit('event stream aborted');
                 reject(err);
             });
 
@@ -270,6 +273,7 @@ class EPGUpdateManageModel extends EventEmitter implements IEPGUpdateManageModel
                     }
                     this.log.system.error(err);
                     this.stopStream(eventStream);
+                    this.emit('event stream aborted');
                     reject(new Error('EventStreamParseError'));
                 }
                 tmp = Buffer.from([]);
@@ -403,7 +407,9 @@ class EPGUpdateManageModel extends EventEmitter implements IEPGUpdateManageModel
      * 現在時刻より古い番組情報を削除
      */
     public async deleteOldPrograms(): Promise<void> {
+        this.log.system.info('delete old program db start');
         await this.programDB.deleteOld(new Date().getTime());
+        this.log.system.info('delete old program db done');
     }
 
     /**

--- a/src/model/epgUpdater/EPGUpdater.ts
+++ b/src/model/epgUpdater/EPGUpdater.ts
@@ -5,6 +5,7 @@ import ILogger from '../ILogger';
 import ILoggerModel from '../ILoggerModel';
 import IEPGUpdateManageModel from './IEPGUpdateManageModel';
 import IEPGUpdater from './IEPGUpdater';
+import Util from '../../util/Util';
 
 @injectable()
 class EPGUpdater implements IEPGUpdater {
@@ -15,6 +16,7 @@ class EPGUpdater implements IEPGUpdater {
     private isEventStreamAlive: boolean = false;
     private lastUpdatedTime: number = 0;
     private lastDeletedTime: number = 0;
+    private retryCount: number = 0;
 
     constructor(
         @inject('ILoggerModel') logger: ILoggerModel,
@@ -29,8 +31,28 @@ class EPGUpdater implements IEPGUpdater {
             this.lastUpdatedTime = new Date().getTime();
             this.notify();
         });
+
         this.updateManage.on('service updated', () => {
             this.notify();
+        });
+
+        this.updateManage.on('event stream started', async () => {
+            this.log.system.info('event stream started');
+            this.retryCount = 0;
+            try {
+                await this.updateManage.updateAll();
+                this.notify();
+            } catch (err: any) {
+                this.log.system.error('updateAll error');
+            }
+            // updateAllが完了して以降、queueフラッシュ処理を有効にするために
+            // この位置でisEventStreamAliveをtrueにする
+            this.isEventStreamAlive = true;
+        });
+
+        this.updateManage.on('event stream aborted', () => {
+            this.log.system.info('has disconnected from the mirakurun');
+            this.isEventStreamAlive = false;
         });
     }
 
@@ -39,46 +61,29 @@ class EPGUpdater implements IEPGUpdater {
      */
     public async start(): Promise<void> {
         this.log.system.info('start EPG update');
-        this.startEventStreamAnalysis();
-        await this.updateManage.updateAll().catch(err => {
-            this.log.system.fatal('epg initialization update error');
-            throw err;
-        });
-        this.notify();
 
         const updateInterval = this.config.epgUpdateIntervalTime * 60 * 1000;
 
-        // EventStream 監視ループ(watchdog)
-        setInterval(async () => {
-            try {
-                if (this.isEventStreamAlive === false) {
-                    // stream event に何らかの問題が発生した
-                    this.startEventStreamAnalysis();
-                    await this.updateManage.updateAll();
-                }
-            } catch (err: any) {
-                this.log.system.error('EPG update error');
-                this.log.system.error(err);
-            }
-        }, 10 * 1000);
+        // event streamを開始
+        this.startEventStreamAnalysis();
 
         // 溜め込んだservice queueを設定ファイルで指定されたサイクルでDBへ保存
         setInterval(async () => {
-            try {
-                if (this.isEventStreamAlive === true) {
+            if (this.isEventStreamAlive === true) {
+                try {
                     await this.updateManage.saveService();
+                } catch (err: any) {
+                    this.log.system.error('service update error');
+                    this.log.system.error(err);
                 }
-            } catch (err: any) {
-                this.log.system.error('service update error');
-                this.log.system.error(err);
             }
         }, updateInterval);
 
         // 放送中や放送開始時刻が間近の番組は短いサイクルでDBへ保存する
         // NOTE: DB負荷などを考慮しEvent受信と同時のDB反映は見合わせる
         setInterval(async () => {
-            const now = new Date().getTime();
             if (this.isEventStreamAlive === true) {
+                const now = new Date().getTime();
                 try {
                     await this.updateManage.saveProgram(now + 5 * 60 * 1000);
                     if (this.lastUpdatedTime + updateInterval <= now) {
@@ -92,12 +97,10 @@ class EPGUpdater implements IEPGUpdater {
 
                 if (this.lastDeletedTime + updateInterval <= now) {
                     // 古い番組情報を削除
-                    this.log.system.info('delete old programs start');
                     await this.updateManage.deleteOldPrograms().catch(err => {
                         this.log.system.error('delete old programs error');
                         this.log.system.error(err);
                     });
-                    this.log.system.info('delete old programs done');
                     this.lastDeletedTime = now;
                 }
             }
@@ -109,12 +112,16 @@ class EPGUpdater implements IEPGUpdater {
      * stream に問題が発生した場合は this.isEventStreamAlive が false になる
      */
     private async startEventStreamAnalysis(): Promise<void> {
-        this.isEventStreamAlive = true;
-        try {
-            await this.updateManage.start();
-        } catch (err: any) {
-            this.log.system.error('destroy event stream');
-            this.isEventStreamAlive = false;
+        while (true) {
+            try {
+                this.log.system.info('trying to connecting to the mirakurun');
+                await this.updateManage.start();
+            } catch (err: any) {
+                this.log.system.error('destroy event stream');
+                this.retryCount++;
+                const retryInterval = Math.min(this.retryCount * 5 * 1000, 60 * 1000);
+                await Util.sleep(retryInterval);
+            }
         }
     }
 

--- a/src/model/epgUpdater/EPGUpdater.ts
+++ b/src/model/epgUpdater/EPGUpdater.ts
@@ -22,6 +22,13 @@ class EPGUpdater implements IEPGUpdater {
         this.log = logger.getLogger();
         this.config = configuration.getConfig();
         this.updateManage = updateManage;
+
+        this.updateManage.on('program updated', () => {
+            this.notify();
+        });
+        this.updateManage.on('service updated', () => {
+            this.notify();
+        });
     }
 
     /**
@@ -37,30 +44,65 @@ class EPGUpdater implements IEPGUpdater {
         this.notify();
 
         const updateTime = this.config.epgUpdateIntervalTime;
+
+        // EventStream 監視ループ(watchdog)
+        setInterval(async () => {
+            try {
+                if (this.isEventStreamAlive === false) {
+                    // stream event に何らかの問題が発生した
+                    this.startEventStreamAnalysis();
+                    await this.updateManage.updateAll();
+                }
+            } catch (err: any) {
+                this.log.system.error('EPG update error');
+                this.log.system.error(err);
+            }
+        }, 10 * 1000);
+
+        // 溜め込んだQueueを設定ファイルで指定されたサイクルでDBへ保存
         setInterval(
             async () => {
                 try {
                     if (this.isEventStreamAlive === true) {
-                        if (this.updateManage.getServiceQueueSize() > 0) {
-                            // queue に更新情報が無ければ実行しない
-                            await this.updateManage.saveSevice();
-                        }
-                        if (this.updateManage.getProgramQueueSize() > 0) {
-                            // queue に更新情報が無ければ実行しない
-                            await this.updateManage.saveProgram();
-                        }
-                    } else {
-                        // stream event に何らかの問題が発生した
-                        this.startEventStreamAnalysis();
-                        await this.updateManage.updateAll();
+                        await this.updateManage.saveService();
                     }
-
-                    this.notify();
                 } catch (err: any) {
-                    this.log.system.error('EPG update error');
+                    this.log.system.error('service update error');
                     this.log.system.error(err);
                 }
+            },
+            updateTime * 60 * 1000,
+        );
+        setInterval(
+            async () => {
+                try {
+                    if (this.isEventStreamAlive === true) {
+                        await this.updateManage.saveProgram();
+                    }
+                } catch (err: any) {
+                    this.log.system.error('program update error');
+                    this.log.system.error(err);
+                }
+            },
+            updateTime * 60 * 1000,
+        );
 
+        // 放送中や放送開始時刻が間近の番組は短いサイクルでDBへ保存する
+        // NOTE: DB負荷などを考慮しEvent受信と同時のDB反映は見合わせる
+        setInterval(async () => {
+            try {
+                if (this.isEventStreamAlive === true) {
+                    const timeThreshold = new Date().getTime() + 5 * 60 * 1000;
+                    await this.updateManage.saveProgram(timeThreshold);
+                }
+            } catch (err: any) {
+                this.log.system.error('EPG update error');
+                this.log.system.error(err);
+            }
+        }, 10 * 1000);
+
+        setInterval(
+            async () => {
                 // 古い番組情報を削除
                 this.log.system.info('delete old programs');
                 await this.updateManage.deleteOldPrograms().catch(err => {
@@ -68,7 +110,7 @@ class EPGUpdater implements IEPGUpdater {
                     this.log.system.error(err);
                 });
             },
-            updateTime * 60 * 1000,
+            30 * 60 * 1000,
         );
     }
 

--- a/src/model/epgUpdater/EPGUpdater.ts
+++ b/src/model/epgUpdater/EPGUpdater.ts
@@ -13,6 +13,8 @@ class EPGUpdater implements IEPGUpdater {
     private updateManage: IEPGUpdateManageModel;
 
     private isEventStreamAlive: boolean = false;
+    private lastUpdatedTime: number = 0;
+    private lastDeletedTime: number = 0;
 
     constructor(
         @inject('ILoggerModel') logger: ILoggerModel,
@@ -24,6 +26,7 @@ class EPGUpdater implements IEPGUpdater {
         this.updateManage = updateManage;
 
         this.updateManage.on('program updated', () => {
+            this.lastUpdatedTime = new Date().getTime();
             this.notify();
         });
         this.updateManage.on('service updated', () => {
@@ -43,7 +46,7 @@ class EPGUpdater implements IEPGUpdater {
         });
         this.notify();
 
-        const updateTime = this.config.epgUpdateIntervalTime;
+        const updateInterval = this.config.epgUpdateIntervalTime * 60 * 1000;
 
         // EventStream 監視ループ(watchdog)
         setInterval(async () => {
@@ -59,59 +62,46 @@ class EPGUpdater implements IEPGUpdater {
             }
         }, 10 * 1000);
 
-        // 溜め込んだQueueを設定ファイルで指定されたサイクルでDBへ保存
-        setInterval(
-            async () => {
-                try {
-                    if (this.isEventStreamAlive === true) {
-                        await this.updateManage.saveService();
-                    }
-                } catch (err: any) {
-                    this.log.system.error('service update error');
-                    this.log.system.error(err);
+        // 溜め込んだservice queueを設定ファイルで指定されたサイクルでDBへ保存
+        setInterval(async () => {
+            try {
+                if (this.isEventStreamAlive === true) {
+                    await this.updateManage.saveService();
                 }
-            },
-            updateTime * 60 * 1000,
-        );
-        setInterval(
-            async () => {
-                try {
-                    if (this.isEventStreamAlive === true) {
-                        await this.updateManage.saveProgram();
-                    }
-                } catch (err: any) {
-                    this.log.system.error('program update error');
-                    this.log.system.error(err);
-                }
-            },
-            updateTime * 60 * 1000,
-        );
+            } catch (err: any) {
+                this.log.system.error('service update error');
+                this.log.system.error(err);
+            }
+        }, updateInterval);
 
         // 放送中や放送開始時刻が間近の番組は短いサイクルでDBへ保存する
         // NOTE: DB負荷などを考慮しEvent受信と同時のDB反映は見合わせる
         setInterval(async () => {
-            try {
-                if (this.isEventStreamAlive === true) {
-                    const timeThreshold = new Date().getTime() + 5 * 60 * 1000;
-                    await this.updateManage.saveProgram(timeThreshold);
+            const now = new Date().getTime();
+            if (this.isEventStreamAlive === true) {
+                try {
+                    await this.updateManage.saveProgram(now + 5 * 60 * 1000);
+                    if (this.lastUpdatedTime + updateInterval <= now) {
+                        await this.updateManage.saveProgram();
+                        this.lastUpdatedTime = now;
+                    }
+                } catch (err: any) {
+                    this.log.system.error('EPG update error');
+                    this.log.system.error(err);
                 }
-            } catch (err: any) {
-                this.log.system.error('EPG update error');
-                this.log.system.error(err);
+
+                if (this.lastDeletedTime + updateInterval <= now) {
+                    // 古い番組情報を削除
+                    this.log.system.info('delete old programs start');
+                    await this.updateManage.deleteOldPrograms().catch(err => {
+                        this.log.system.error('delete old programs error');
+                        this.log.system.error(err);
+                    });
+                    this.log.system.info('delete old programs done');
+                    this.lastDeletedTime = now;
+                }
             }
         }, 10 * 1000);
-
-        setInterval(
-            async () => {
-                // 古い番組情報を削除
-                this.log.system.info('delete old programs');
-                await this.updateManage.deleteOldPrograms().catch(err => {
-                    this.log.system.error('delete old programs error');
-                    this.log.system.error(err);
-                });
-            },
-            30 * 60 * 1000,
-        );
     }
 
     /**

--- a/src/model/epgUpdater/IEPGUpdateManageModel.ts
+++ b/src/model/epgUpdater/IEPGUpdateManageModel.ts
@@ -1,5 +1,9 @@
+import { EventEmitter } from 'events';
 import * as mapid from '../../../node_modules/mirakurun/api';
 
+export interface RemoveProgram {
+    id: mapid.ProgramId;
+}
 export interface RedefineProgram {
     from: mapid.ProgramId;
     to: mapid.ProgramId;
@@ -7,7 +11,7 @@ export interface RedefineProgram {
 
 export interface ProgramBaseEvent extends mapid.Event {
     resource: 'program';
-    data: RedefineProgram | mapid.Program;
+    data: RedefineProgram | RemoveProgram | mapid.Program;
 }
 
 export interface CreateEvent extends ProgramBaseEvent {
@@ -20,6 +24,11 @@ export interface UpdateEvent extends ProgramBaseEvent {
     data: mapid.Program;
 }
 
+export interface RemoveEvent extends ProgramBaseEvent {
+    type: 'remove';
+    data: RemoveProgram;
+}
+
 export interface RedefineEvent extends ProgramBaseEvent {
     type: 'remove';
     data: RedefineProgram;
@@ -30,13 +39,13 @@ export interface ServiceEvent extends mapid.Event {
     data: mapid.Service;
 }
 
-export default interface IEPGUpdateManageModel {
+export default interface IEPGUpdateManageModel extends EventEmitter {
     updateAll(): Promise<void>;
     updateChannels(): Promise<void>;
     start(): Promise<void>;
     getProgramQueueSize(): number;
     getServiceQueueSize(): number;
-    saveProgram(): Promise<void>;
+    saveProgram(timeThreshold?: number): Promise<void>;
     deleteOldPrograms(): Promise<void>;
-    saveSevice(): Promise<void>;
+    saveService(): Promise<void>;
 }

--- a/src/model/operator/recording/IRecordingStreamCreator.ts
+++ b/src/model/operator/recording/IRecordingStreamCreator.ts
@@ -4,7 +4,7 @@ import Reserve from '../../../db/entities/Reserve';
 
 interface IRecordingStreamCreator {
     setTuner(tuners: mapid.TunerDevice[]): void;
-    create(reserve: Reserve): Promise<http.IncomingMessage>;
+    create(reserve: Reserve, abortSignal?: AbortSignal): Promise<http.IncomingMessage>;
     changeEndAt(reserve: Reserve): void;
 }
 


### PR DESCRIPTION
## 概要(Summary)
番組の放送時刻変更および番組の組み替えに伴う番組削除への対応を強化

## 内容
### epgUpdater
- 番組編成変更に迅速に対応するため、epgUpdateIntervalTime間隔のキューのフラッシュに追加して、受信した番組がすでに開始している（※放送終了の変更）か開始時刻が5分以内の番組がキューにあれば迅速にdbへフラッシュする
- キューをフラッシュする必要がなかった場合は"updated"イベントを通知せず、スケジュールの無駄な更新を避ける
- 番組が削除された際の処理に問題があったため改善した。このことで、削除された番組が番組表に存在し続けて、正しい番組が裏に隠れて見えなくなる事象が解消する
### recording
- 録画中の場合、スケジュール更新によるキャンセルは行わない。これは、EPGstationの番組情報の更新が間に合わなかたことを示す事象であるから。録画を継続しても影響はない
- preprec（スタンバイ中）の番組の開始時刻変更を検知した場合はprecrecをキャンセルする。この際、10分ほどの通信タイムアウトを待たないでmirakurunとの通信を即座に閉じるためabortSignalを使用
- 録画対象の直前の番組が終了時刻延長になった場合、mirakurunから番組削除電文が届く場合がる。これにより録画が失敗しずらい様対処した（当該番組が存在しない状態でスケジュール更新すると警告は出力されるがレコードは削除されない様である。mirakurunから新しい当該番組情報が届けばスケジュールは正常に戻る）　※この事象をさらに改善するためにmirakurunへプルリクエストを行ったが取り込まれるかは現時点で不明